### PR TITLE
Hotfix/not refreshing last app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Not refreshing last app version number
 ## [0.2.0] - 2020-12-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Not refreshing last app version number
+- Applying translated warning message
 ## [0.2.0] - 2020-12-23
 
 ### Added

--- a/react/Admin.tsx
+++ b/react/Admin.tsx
@@ -130,6 +130,7 @@ const Admin: FC<any & WrappedComponentProps> = ({
         ...state,
         ...res.getLast,
         publishedVersion: res.getLast.appVersion,
+        appVersion: config.getSetupConfig.adminSetup.appVersion,
         currentTab: 1,
         colors: {
           ...state.colors,

--- a/react/Admin.tsx
+++ b/react/Admin.tsx
@@ -306,8 +306,7 @@ const Admin: FC<any & WrappedComponentProps> = ({
               state.publishedVersion &&
               state.appVersion !== state.publishedVersion && (
                 <Alert type="warning">
-                  New checkout version available, click PUBLISH if you want to
-                  update your Store&apos;s checkout
+                  <FormattedMessage id="admin/checkout-ui.update-warning" />
                 </Alert>
               )}
             <Tabs fullWidth>


### PR DESCRIPTION
### Fixed

- Not refreshing last app version number
- Applying translated warning message