### PR TITLE
[CHECKOUTUI-80] limit access to checkout ui app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added Licence manager product ID in order to restrict access to other users
+
 ## [0.7.10] - 2022-07-07
 
 ### Fixed

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -2,7 +2,7 @@
   {
     "section": "storeSetup",
     "titleId": "admin/checkout-ui.navigation.title",
-    "path": "/private/admin/vtex-checkout-ui-custom/",
+    "path": "/admin/private/vtex-checkout-ui-custom/",
     "LMProductId": "5"
   },
   {

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -2,7 +2,7 @@
   {
     "section": "storeSetup",
     "titleId": "admin/checkout-ui.navigation.title",
-    "path": "/admin/vtex-checkout-ui-custom/",
+    "path": "/private/admin/vtex-checkout-ui-custom/",
     "LMProductId": "5"
   },
   {
@@ -13,7 +13,7 @@
     "subSectionItems": [
       {
         "labelId": "admin/checkout-ui.navigation.title",
-        "path": "/admin/vtex-checkout-ui-custom/"
+        "path": "/admin/private/vtex-checkout-ui-custom/"
       }
     ]
   }

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -2,18 +2,18 @@
   {
     "section": "storeSetup",
     "titleId": "admin/checkout-ui.navigation.title",
-    "path": "/admin/private/vtex-checkout-ui-custom/",
-    "LMProductId": "5"
+    "path": "/admin/vtex-checkout-ui-custom/",
+    "LMProductId": "27"
   },
   {
     "section": "storeSettings",
     "subSection": "storeFront",
     "adminVersion": 4,
-    "LMProductId": "5",
+    "LMProductId": "27",
     "subSectionItems": [
       {
         "labelId": "admin/checkout-ui.navigation.title",
-        "path": "/admin/private/vtex-checkout-ui-custom/"
+        "path": "/admin/vtex-checkout-ui-custom/"
       }
     ]
   }

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -2,12 +2,14 @@
   {
     "section": "storeSetup",
     "titleId": "admin/checkout-ui.navigation.title",
-    "path": "/admin/vtex-checkout-ui-custom/"
+    "path": "/admin/vtex-checkout-ui-custom/",
+    "LMProductId": "5"
   },
   {
     "section": "storeSettings",
     "subSection": "storeFront",
     "adminVersion": 4,
+    "LMProductId": "5",
     "subSectionItems": [
       {
         "labelId": "admin/checkout-ui.navigation.title",


### PR DESCRIPTION
## Changes made:
- Add LMProduct Id to the navigations in order to limit access to call center operators

## Workspace to test this on:
- You can test this [here](https://beto--vinnerenio.myvtex.com/admin)

## Testing: 
- Added my personal email to restrict access to the app

## Screenshot of changes:
![Image 2022-07-06 at 1 13 14 p m](https://user-images.githubusercontent.com/11176519/177616064-41a6cb08-1ab6-45c3-b21e-691c29e71be4.jpg)
