### PR TITLE
Remove extra address form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed extra address form added to the smart checkout for returning users
+
 ## [0.8.32] - 2023-01-11
 
 ### Removed

--- a/checkout-ui-custom/src/_js/_customAddressForm.js
+++ b/checkout-ui-custom/src/_js/_customAddressForm.js
@@ -523,6 +523,8 @@ class fnsCustomAddressForm {
 
     const { isPickupPoint } = this
 
+    const returningUser = orderForm.canEditData
+
     const form = `
       <div class="vcustom--vtex-omnishipping-1-x-address step">
         <div>
@@ -650,7 +652,8 @@ class fnsCustomAddressForm {
       $('.vcustom--vtex-omnishipping-1-x-address.step').length == 0 &&
       shippingData.logisticsInfo[0].selectedDeliveryChannel !==
         'pickup-in-point' &&
-      window.location.href.indexOf('shipping') !== -1
+      window.location.href.indexOf('shipping') !== -1 &&
+      !returningUser
     ) {
       $('.orderform-template-holder #shipping-data').append(form)
     }


### PR DESCRIPTION
This PR removes the extra address form that is appended on the smart checkout. Currently, after a returning user clicks on 'Go To Payment' after inputing the email in smart checkout, the smart checkout takes them directly to the Address Form Step, which should be the Payment Step instead.
https://app.birdeatsbug.com/sessions/9foshCp895AWFL65pDzewuz1YDgrDUcczNStn-gadvSH