### PR TITLE
fix: append coupon by SKU instead of index

### DIFF
--- a/checkout-ui-custom/src/_js/_v.custom.checkout.ui.js
+++ b/checkout-ui-custom/src/_js/_v.custom.checkout.ui.js
@@ -333,7 +333,7 @@ class checkoutCustom {
             }).length > 0
           ) {
             _couponItems.push(this)
-            $(`.table.cart-items tbody tr.product-item:eq(${i})`)
+            $(`.table.cart-items tbody tr.product-item[data-sku='${this.id}']`)
               .addClass('v-custom-addLabels-active js-vcustom-addLabels')
               .find('.product-name')
               .append(


### PR DESCRIPTION
We are trying to organize products by categories in the shopping cart. Currently, when coupons are added, it is done using the index of the orderForm, which follows the order of 0, 1, 2, 3, etc. In this case, when we reorder by categories, the coupons end up in incorrect positions because the order of items in the orderForm no longer matches the one seen on the website. Therefore, we would like to propose a change in the insertion process, to do it by SKU instead of the order number.
**current**
![image](https://github.com/vtex-apps/checkout-ui-custom/assets/40153830/22828c4e-1ee3-43ee-8659-ad7b1f185416)
![image](https://github.com/vtex-apps/checkout-ui-custom/assets/40153830/2de2aa6a-df73-40d2-a635-ed8c08e02d0f)

**new**
![image](https://github.com/vtex-apps/checkout-ui-custom/assets/40153830/e5ce8888-cacb-436a-8c34-4c9231abcbad)
![image](https://github.com/vtex-apps/checkout-ui-custom/assets/40153830/5ffe569c-400f-4688-93f6-e9237b3ccc97)
