### PR TITLE
Fix the trim() error that happens at checkout when the user goes to the payment hash on safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix: removes trim() from shipping validation
+
 ## [0.15.4] - 2024-01-10
 
 ## [0.15.3] - 2024-01-09

--- a/checkout-ui-custom/src/_js/_v.custom.checkout.ui.js
+++ b/checkout-ui-custom/src/_js/_v.custom.checkout.ui.js
@@ -565,7 +565,7 @@ class checkoutCustom {
 
       if(typeDays === "d") {
         d.setDate(
-          d.getDate() + n 
+          d.getDate() + n
         )
       } else {
         d.setDate(
@@ -1105,7 +1105,7 @@ class checkoutCustom {
       orderForm.shippingData &&
       orderForm.shippingData.address &&
       orderForm.shippingData.address.addressType !== 'search' &&
-      !orderForm.shippingData.address.street.trim() &&
+      orderForm.shippingData.address.street &&
       _this.customAddressForm
     ) {
       _this.goToShippingStep()


### PR DESCRIPTION
### Objective of this PR:

- Fix the trim() error that happens at checkout when the user goes to the payment hash on safari

### Evidence
![image](https://github.com/vtex-apps/checkout-ui-custom/assets/34255207/89b60978-2e68-42a2-820d-61d5a601f8d4)

### Workspace
https://eris--hunterdouglasnl.myvtex.com/checkout/#/payment