### PR TITLE
Bump app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update version to clean possible poisoned cache due to an IO db update
+
 ## [0.17.1] - 2024-02-16
 
 ### Fixed


### PR DESCRIPTION
There might be a invalid cache for this application after a procedure to update the IO database version. Bumping version to invalidate the cache on redis that might be serving a wrong version of the application.