### PR TITLE
Bump version of address-form reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Updated version reference to Address-form in order to reflect Malta's locale addition
+
 ## [0.18.3] - 2024-04-30
 
 ## [0.18.2] - 2024-04-29

--- a/checkout-ui-custom/package.json
+++ b/checkout-ui-custom/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/runtime-corejs2": "^7.0.0",
-    "@vtex/address-form": "^3.27.2",
+    "@vtex/address-form": "^3.35.4",
     "babel-loader": "^8.0.0",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.0",

--- a/checkout-ui-custom/package.json
+++ b/checkout-ui-custom/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/runtime-corejs2": "^7.0.0",
-    "@vtex/address-form": "^3.35.4",
+    "@vtex/address-form": "^3.35.0",
     "babel-loader": "^8.0.0",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.0",

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.checkout-ui-custom",
   "version": "0.18.3",
   "dependencies": {
-    "@vtex/address-form": "^3.27.2",
+    "@vtex/address-form": "^3.35.4",
     "@vtex/api": "6.46.1",
     "co-body": "^6.0.0",
     "ramda": "^0.25.0"

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.checkout-ui-custom",
   "version": "0.18.3",
   "dependencies": {
-    "@vtex/address-form": "^3.35.4",
+    "@vtex/address-form": "^3.35.0",
     "@vtex/api": "6.46.1",
     "co-body": "^6.0.0",
     "ramda": "^0.25.0"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -261,10 +261,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/address-form@^3.27.2":
-  version "3.27.2"
-  resolved "https://registry.yarnpkg.com/@vtex/address-form/-/address-form-3.27.2.tgz#045bcd2c8a8b021ba96977ddb0b2cf4ff64863ae"
-  integrity sha512-T6yWQC7+DajbQ8JRcdsLNhjyLF1pjXSvrXy/QgPYf4EGkwkT1qgc4vaE8pOqBZyiHM7kz+Mg5PlkiUrUHXLcJA==
+"@vtex/address-form@^3.35.0":
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/@vtex/address-form/-/address-form-3.35.0.tgz#f090d71f76865338b39952964d2fc562d729e2fa"
+  integrity sha512-BcFR9f6A2Zcbw5qdhIqqoOgHiyWRfyk8GsLQWl3/jgu4LV+d7k895MN7UzBbCKQIZGMsh2Pd2rqeSoKFe1ZhKA==
   dependencies:
     "@vtex/styleguide" "^9.112.28"
     axios "^0.16.2"
@@ -272,6 +272,7 @@
     load-google-maps-api "^1.0.0"
     lodash "^4.17.4"
     msk "^1.0.5"
+    react-intl "^2.8.0"
     recompose "^0.27.1"
 
 "@vtex/api@6.46.1":
@@ -1430,6 +1431,13 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
+hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 http-assert@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.5.0.tgz#c389ccd87ac16ed2dfa6246fd73b926aa00e6b8f"
@@ -1521,7 +1529,31 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-invariant@^2.2.4:
+intl-format-cache@^2.0.5:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.2.9.tgz#fb560de20c549cda20b569cf1ffb6dc62b5b93b4"
+  integrity sha512-Zv/u8wRpekckv0cLkwpVdABYST4hZNTDaX7reFetrYTJwxExR2VyTqQm+l0WmL0Qo8Mjb9Tf33qnfj0T7pjxdQ==
+
+intl-messageformat-parser@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz#b43d45a97468cadbe44331d74bb1e8dea44fc075"
+  integrity sha512-/XkqFHKezO6UcF4Av2/Lzfrez18R0jyw7kRFhSeB/YRakdrgSc9QfFZUwNJI9swMwMoNPygK1ArC5wdFSjPw+A==
+
+intl-messageformat@^2.0.0, intl-messageformat@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.2.0.tgz#345bcd46de630b7683330c2e52177ff5eab484fc"
+  integrity sha512-I+tSvHnXqJYjDfNmY95tpFMj30yoakC6OXAo+wu/wTMy6tA/4Fd4mvV7Uzs4cqK/Ap29sHhwjcY+78a8eifcXw==
+  dependencies:
+    intl-messageformat-parser "1.4.0"
+
+intl-relativeformat@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-2.2.0.tgz#6aca95d019ec8d30b6c5653b6629f9983ea5b6c5"
+  integrity sha512-4bV/7kSKaPEmu6ArxXf9xjv1ny74Zkwuey8Pm01NH4zggPP7JHwg2STk8Y3JdspCKRDriwIyLRfEXnj2ZLr4Bw==
+  dependencies:
+    intl-messageformat "^2.0.0"
+
+invariant@^2.1.1, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -2353,7 +2385,18 @@ react-input-autosize@^2.2.1:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.13.1, react-is@^16.3.2:
+react-intl@^2.8.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.9.0.tgz#c97c5d17d4718f1575fdbd5a769f96018a3b1843"
+  integrity sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==
+  dependencies:
+    hoist-non-react-statics "^3.3.0"
+    intl-format-cache "^2.0.5"
+    intl-messageformat "^2.1.0"
+    intl-relativeformat "^2.1.0"
+    invariant "^2.1.1"
+
+react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
It relates to the task [LOC-14346](https://vtex-dev.atlassian.net/browse/LOC-14346) and to [this Slack thread](https://vtex.slack.com/archives/CT0S37223/p1714054186591079), in which it was stated to update the Address-form reference in order for the addition of Malta locale to work properly on customized checkouts.
The reference was updated to [version 3.35.4](https://vtex.slack.com/archives/CT98SSTU4/p1715021210675029) 

[LOC-14346]: https://vtex-dev.atlassian.net/browse/LOC-14346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ