### PR TITLE
fix: solving ios 12.4 problem

### DIFF
--- a/checkout-ui-custom/src/_scss/_components/_global.scss
+++ b/checkout-ui-custom/src/_scss/_components/_global.scss
@@ -6,7 +6,7 @@ body {
   padding: 0;
   background: $base;
   padding-bottom:40px !important;
- 
+
   min-height: 93vh;
   position: relative;
   font-size: $fontSize;
@@ -20,27 +20,56 @@ body {
     }
   }
 
-  @media(max-width: 768px) { 
+  @media(max-width: 768px) {
     padding-bottom:0px !important;
   }
 
-  //short preloader to don't show a empty cart
-  .cart-template.full-cart {
-    > * {
-      opacity: 0;
-      transition-delay:1.2s;
-      transition-property: opacity;
-      -webkit-transition-duration:0.5s;
-    }
-  }
-  &.v-custom-loaded {
-    .cart-template.full-cart {
-      > * {opacity: initial;}
-    }
-  }
-  //end short preloader to don't show a empty cart
+    .checkout-container {
+      .cart-template.full-cart {
+        >* {
+          opacity: initial;
+          transition-delay: 1.2s;
+          transition-property: opacity;
+          -webkit-transition-duration: 0.5s;
+        }
+      }
 
-  &.returningUser.v-custom-addressForm-on.v-custom-step-shipping 
+      &.v-custom-loaded {
+        .cart-template.full-cart {
+          >* {
+            opacity: initial;
+          }
+        }
+      }
+
+      .orderform-template .cart-template.mini-cart .cart .cart-items {
+        max-height: none;
+        overflow: auto;
+
+        &::after,
+        &::before {
+          display: none;
+        }
+
+        li.item {
+          float: none;
+          overflow: auto;
+          opacity: initial;
+
+          &::after,
+          &::before {
+            display: none;
+          }
+
+          &>* {
+            opacity: initial;
+            z-index: 1;
+          }
+        }
+      }
+    }
+
+  &.returningUser.v-custom-addressForm-on.v-custom-step-shipping
   .accordion-inner.shipping-container  {
 
     .vtex-omnishipping-1-x-addressFormPart1.vtex-omnishipping-1-x-geolocation {
@@ -64,9 +93,9 @@ body {
 
 .container-main {
 }
- 
+
 .loading.loading-bg {
-  background:$base; 
+  background:$base;
 }
 
 // containers
@@ -147,13 +176,13 @@ body {
       list-style: none;
       padding: 0;
       margin: 0;
-      
+
       &__item {
         strong {
           &:after {content:":";}
         }
         span, strong {line-height: 14px;}
       }
-    } 
-     
+    }
+
   }


### PR DESCRIPTION
## Fix: Checkout UI Custom Not Working as it should on iOS Safari (12.4–13.6)

### Context

We identified a compatibility issue affecting all clients using **VTEX Checkout UI Custom**. The issue occurred specifically on **iOS devices running versions 12.4 up to 13.6**, when accessed via **Safari**.

### Problem

In these iOS versions, the custom Checkout UI failed to render or function correctly, resulting in a broken or inaccessible checkout experience for users. This was caused by limitations or inconsistencies in how Safari handles certain scripts or UI rendering in those specific OS versions.

The root of the issue lies in how VTEX manages certain actions within the checkout through specific class injections. One of those classes is `v-loaded`, which is dynamically added to certain blocks after the page finishes loading. On some older iOS devices, this class is not being applied correctly, causing those blocks to miss styling that depends on the `v-loaded` class.

### Solution

While it would have been possible to inject the `v-loaded` class via JavaScript, the chosen approach focused on performance and maintainability. Therefore, this fix was implemented purely in SCSS, ensuring the blocks receive appropriate styling regardless of whether the class is applied.

### Workspace

[Checkout Test Workspace](https://fixcheckout--mobfiqpartnerbr.myvtex.com/checkout#/cart)

### Impact

- Restores correct styling and layout behavior for the Checkout UI Custom on iOS Safari 12.4 to 13.6.
- Ensures fallback styles apply even when the `v-loaded` class fails to render.
- Performance-focused fix, avoiding unnecessary JavaScript injections.
- No adverse effect on newer iOS versions or other browsers.
